### PR TITLE
guard: Create Predictive PEL for guard file read exception

### DIFF
--- a/extensions/phal/create_pel.cpp
+++ b/extensions/phal/create_pel.cpp
@@ -91,18 +91,21 @@ void createErrorPEL(const std::string& event, const json& calloutData,
 
     try
     {
-        FFDCFile ffdcFile(calloutData);
-
         std::vector<std::tuple<sdbusplus::xyz::openbmc_project::Logging::
                                    server::Create::FFDCFormat,
                                uint8_t, uint8_t, sdbusplus::message::unix_fd>>
             pelCalloutInfo;
 
-        pelCalloutInfo.push_back(
-            std::make_tuple(sdbusplus::xyz::openbmc_project::Logging::server::
-                                Create::FFDCFormat::JSON,
-                            static_cast<uint8_t>(0xCA),
-                            static_cast<uint8_t>(0x01), ffdcFile.getFileFD()));
+        if (!calloutData.is_null())
+        {
+            FFDCFile ffdcFile(calloutData);
+
+            pelCalloutInfo.push_back(std::make_tuple(
+                sdbusplus::xyz::openbmc_project::Logging::server::Create::
+                    FFDCFormat::JSON,
+                static_cast<uint8_t>(0xCA), static_cast<uint8_t>(0x01),
+                ffdcFile.getFileFD()));
+        }
 
         std::string service =
             util::getService(bus, loggingObjectPath, loggingInterface);

--- a/extensions/phal/phal_error.hpp
+++ b/extensions/phal/phal_error.hpp
@@ -57,6 +57,15 @@ void processBootError(bool status);
 void processSbeBootError();
 
 /**
+ * @brief Process Guard File Read failure status
+ *
+ * This function is used for Guard File Read failure handling during
+ * boot. It collects the traces and create a PEL
+ * Also resets the trace buffer.
+ */
+void processGuardFileReadError(const ipl_error_info& errInfo);
+
+/**
  * @brief Reset trace log list
  */
 void reset();

--- a/meson.build
+++ b/meson.build
@@ -120,6 +120,7 @@ if build_phal
         cxx.find_library('ipl'),
         cxx.find_library('phal'),
         cxx.find_library('dtree'),
+        cxx.find_library('libguard'),
     ]
     extra_unit_files = [
         'service_files/set-spi-mux.service',


### PR DESCRIPTION
-Currently whenever there is an exception related to guard file, we do not log a PEL to indicate the same.
-Adding the IPL_ERR_GUARD_FILE_READ enables us to generate the PEL -The "FileLocation" and "Reason" in "User Data 1" provides more information regarding the PEL

Tested:
Using the above error in the ipl callback, able to generate the below generic PEL and put the host into quiesced state

"0x5000644A": {
"SRC": "BD8D100C",
"Message": "Failed to read to a file",
"PLID": "0x5000644A",
"CreatorID": "BMC",
"Subsystem": "BMC Firmware",
"Commit Time": "09/29/2022 16:46:03",
"Sev": "Predictive Error",
"CompID": "0x1000"
},

peltool -i 0x5000643F
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x1000",
    "Created at":               "09/29/2022 16:38:28",
    "Committed at":             "09/29/2022 16:38:28",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x5000643F",
    "Entry Id":                 "0x5000643F",
    "BMC Event Log Id":         "507"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "0x2000",
    "Subsystem":                "BMC Firmware",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "0x1000",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2F",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "Failed to read to a file"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD8D100C",
    "Hex Word 2":               "00080055",
    "Hex Word 3":               "2E2F0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this type as a
unit",
            "Procedure":        "BMC0001"
        }]
    }
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Reporting Machine Type":   "9105-42A",
    "Reporting Serial Number":  "13BE960",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1020.20-8",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD8D100C_2E2F0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Machine Type Model":       "9105-42A",
    "Serial Number":            "13BE960"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "BMCState": "Ready",
    "BootState": "Unspecified",
    "ChassisState": "On",
    "FW Version ID": "fw1020.20-8-2-g52578570b9",
    "HostState": "TransitioningToRunning",
    "Process Name": "/usr/bin/openpower-proc-control",
    "System IM": "50001000"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "FileLocation": "/var/lib/phosphor-software-manager/hostfw/running/GUARD",
    "LOG000 2022-09-29 16:38:27": "Found a POWER10 OpenBMC based system\n",
    "LOG001 2022-09-29 16:38:27": "Path reference \"/proc4/fsi\" not found,
ignoring\n",
    "LOG002 2022-09-29 16:38:27": "Path reference \"/proc4/pib\" not found,
ignoring\n",
    "LOG003 2022-09-29 16:38:27": "Path reference \"/proc5/fsi\" not found,
ignoring\n",
    "LOG004 2022-09-29 16:38:27": "Path reference \"/proc5/pib\" not found,
ignoring\n",
    "LOG005 2022-09-29 16:38:27": "Path reference \"/proc6/fsi\" not found,
ignoring\n",
    "LOG006 2022-09-29 16:38:27": "Path reference \"/proc6/pib\" not found,
ignoring\n",
    "LOG007 2022-09-29 16:38:27": "Path reference \"/proc7/fsi\" not found,
ignoring\n",
    "LOG008 2022-09-29 16:38:27": "Path reference \"/proc7/pib\" not found,
ignoring\n",
    "LOG009 2022-09-29 16:38:27": "IPL mode set to AUTOBOOT\n",
    "LOG010 2022-09-29 16:38:27": "IPL type NORMAL\n",
    "LOG011 2022-09-29 16:38:28": "Istep: updatehwmodel: started\n",
    "LOG012 2022-09-29 16:38:28": "updatehwmodel: Genesis mode boot\n",
    "Reason": "Exception thrown as failed to open the guard file",
    "_PID": "3528"
}
}

CurrentBMCState : xyz.openbmc_project.State.BMC.BMCState.Ready CurrentPowerState : xyz.openbmc_project.State.Chassis.PowerState.On CurrentHostState : xyz.openbmc_project.State.Host.HostState.Quiesced BootProgress :
xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified OperatingSystemState:
xyz.openbmc_project.State.OperatingSystem.Status.OSStatus.Inactive